### PR TITLE
Support: Upload on root dir

### DIFF
--- a/cd_drive/drive.py
+++ b/cd_drive/drive.py
@@ -119,7 +119,9 @@ class Drive:
         return fh
 
     def write(self, filename, mimetype, filepath=None, buff=None):
-        file_metadata = {'name': filename, "parents": [self.current_dir_id]}
+        file_metadata = {'name': filename }
+        if self.current_dir_id:
+            file_metadata["parents"] = [self.current_dir_id]
 
         if buff:
             media = MediaIoBaseUpload(buff, mimetype=mimetype, resumable=True)


### PR DESCRIPTION
Signed-off-by: José Luis Di Biase <josx@interorganic.com.ar>

Now you can upload a file to gdrive root dir
